### PR TITLE
wip: string sample numbers

### DIFF
--- a/helaocore/models/sample.py
+++ b/helaocore/models/sample.py
@@ -89,7 +89,7 @@ class _BaseSample(SampleModel):
     # action_timestamp: Optional[str]  # "%Y%m%d.%H%M%S%f"
 
     # labels
-    sample_no: Optional[int] = None
+    sample_no: Optional[int|str] = None
     machine_name: Optional[str] = None
     sample_hash: Optional[str] = None
     server_name: Optional[str] = None
@@ -220,7 +220,7 @@ class SolidSample(_BaseSample):
 
     sample_type: Literal[SampleType.solid] = SampleType.solid
     machine_name: Optional[str] = "legacy"
-    plate_id: Optional[int] = None
+    plate_id: Optional[int|str] = None
 
     def exp_dict(self):
         exp_dict = self.create_initial_exp_dict()


### PR DESCRIPTION
relax sample_no and plate_id data type to allow strings for diagnostic purposes, these will not validate on upload to S3 / API tables